### PR TITLE
Run confd before starting up when CONFD_BACKEND=ENV is set.

### DIFF
--- a/Dockerfile.no-systemd
+++ b/Dockerfile.no-systemd
@@ -30,6 +30,7 @@ ONBUILD COPY config/confd /etc/confd
 
 # Script that derives typical environment variables from BALENA_TLD.
 COPY src/configure-balena-host-envvars.sh /usr/bin/configure-balena-host-envvars.sh
+COPY src/configure-balena-root-ca.sh /usr/sbin/configure-balena-root-ca.sh
 
 # Confd binary installation.
 ENV CONFD_VERSION 0.16.0

--- a/src/confd-entry.sh
+++ b/src/confd-entry.sh
@@ -13,9 +13,17 @@ fi
 # Set some typical missing env variables (like BALENA_API_HOST) deriving them from BALENA_TLD.
 # Used in BoB.
 /usr/bin/configure-balena-host-envvars.sh
+
 set -a
 # It's an optional step, ok to fail.
 source /etc/docker.env 2>/dev/null && echo "info: Missing typical variables are set using BALENA_TLD"
 set +a
+
+if [[ "$CONFD_BACKEND" = "ENV" ]]; then
+  /usr/local/bin/confd -onetime -confdir=/usr/src/app/config/confd -backend env || exit 1
+  set -a
+  source /usr/src/app/config/env >/dev/null && echo "info: Sourcing /usr/src/app/config/env"
+  set +a
+fi
 
 exec $@

--- a/src/confd-entry.sh
+++ b/src/confd-entry.sh
@@ -19,6 +19,9 @@ set -a
 source /etc/docker.env 2>/dev/null && echo "info: Missing typical variables are set using BALENA_TLD"
 set +a
 
+# Set up certificate pointed to by BALENA_ROOT_CA
+/usr/sbin/configure-balena-root-ca.sh
+
 if [[ "$CONFD_BACKEND" = "ENV" ]]; then
   /usr/local/bin/confd -onetime -confdir=/usr/src/app/config/confd -backend env || exit 1
   set -a


### PR DESCRIPTION
This is required to port open-balena services over to the non-systemd
base-image variant.

Change-type: minor
Signed-off-by: Robert Günzler <robertg@balena.io>