### PR TITLE
Update no-systemd variant

### DIFF
--- a/src/balena-host-envvars.service
+++ b/src/balena-host-envvars.service
@@ -4,7 +4,7 @@ Description=balena-host-envvars
 [Service]
 Type=oneshot
 EnvironmentFile=/etc/docker.env
-ExecStart=/usr/sbin/configure-balena-host-envvars.sh
+ExecStart=/bin/sh -c 'while ! /usr/sbin/configure-balena-host-envvars.sh; do sleep 3s; done'
 RemainAfterExit=true
 
 [Install]

--- a/src/balena-root-ca.service
+++ b/src/balena-root-ca.service
@@ -4,7 +4,7 @@ Description=balena-root-ca
 [Service]
 Type=oneshot
 EnvironmentFile=/etc/docker.env
-ExecStart=/usr/sbin/configure-balena-root-ca.sh
+ExecStart=/bin/sh -c 'while ! /usr/sbin/configure-balena-root-ca.sh; do sleep 3s; done'
 RemainAfterExit=true
 
 [Install]

--- a/src/confd-entry.sh
+++ b/src/confd-entry.sh
@@ -1,21 +1,23 @@
 #!/usr/bin/env bash
 
-if [[ "$BALENA_USE_CONFD" = "1" ]]; then
-  # When this environment variable is set, we need to pull configuration from etcd.
-  # The image is expected to have an environment file template located in /etc/confd,
-  # and this template should be configured to rencer the actual file to /balena/env.
-  /usr/local/bin/confd -onetime -node http://172.17.42.1:4001 || exit 1
-  set -a
-  source /balena/env || exit 1
-  set +a
+# https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
+set -x
+
+USE_CONFD=${USE_CONFD:-$BALENA_USE_CONFD}
+
+if [[ $USE_CONFD -eq 1 ]]; then
+  /usr/local/bin/confd \
+    -onetime \
+    -confdir=/usr/src/app/config/confd \
+    -backend env
+
+  set -a; [ -f /usr/src/app/config/env ] && source /usr/src/app/config/env; set +a
 fi
 
-# Set some typical missing env variables (like BALENA_API_HOST) deriving them from BALENA_TLD.
-# Used in BoB.
 /usr/bin/configure-balena-host-envvars.sh
-set -a
-# It's an optional step, ok to fail.
-source /etc/docker.env 2>/dev/null && echo "info: Missing typical variables are set using BALENA_TLD"
-set +a
 
-exec $@
+/usr/bin/configure-balena-root-ca.sh
+
+set -a; [ -f /etc/docker.env ] && source /etc/docker.env; set +a
+
+exec "$@"


### PR DESCRIPTION
* fix entrypoint script no-systemd variant, which I can only find in-use in analytics-client (balena-data) and even there, the broken etcd flow doesn't kick in because the controlling env var isn't set
* add retry to one-shot services (work around for a race condition in `update-ca-certificates` script?)

```sh
root@a71602a86b27:/usr/src/app# apt install ca-certificates
Reading package lists... Done
Building dependency tree       
Reading state information... Done
ca-certificates is already the newest version (20200601~deb10u2).


root@a71602a86b27:/usr/src/app# journalctl -u balena-root-ca.service -f
-- Logs begin at Thu 2021-08-05 18:20:52 UTC. --
Aug 05 18:20:53 a71602a86b27 systemd[1]: Starting balena-root-ca...
Aug 05 18:20:53 a71602a86b27 configure-balena-root-ca.sh[54]: Installing self-signed balena root CA...
Aug 05 18:20:53 a71602a86b27 configure-balena-root-ca.sh[54]: Updating certificates in /etc/ssl/certs...
Aug 05 18:20:53 a71602a86b27 configure-balena-root-ca.sh[54]: /usr/sbin/update-ca-certificates: 169: /usr/sbin/update-ca-certificates: cannot open /tmp/ca-certificates.tmp.iAkxh7: No such file
Aug 05 18:20:53 a71602a86b27 systemd[1]: balena-root-ca.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Aug 05 18:20:53 a71602a86b27 systemd[1]: balena-root-ca.service: Failed with result 'exit-code'.
Aug 05 18:20:53 a71602a86b27 systemd[1]: Failed to start balena-root-ca.


root@a71602a86b27:/usr/src/app# systemctl restart balena-root-ca.service


root@a71602a86b27:/usr/src/app# journalctl -u balena-root-ca.service -f
-- Logs begin at Thu 2021-08-05 18:20:52 UTC. --
...
Aug 05 18:24:07 a71602a86b27 systemd[1]: Starting balena-root-ca...
Aug 05 18:24:07 a71602a86b27 configure-balena-root-ca.sh[1192]: Installing self-signed balena root CA...
Aug 05 18:24:07 a71602a86b27 configure-balena-root-ca.sh[1192]: Updating certificates in /etc/ssl/certs...
Aug 05 18:24:07 a71602a86b27 configure-balena-root-ca.sh[1192]: 0 added, 0 removed; done.
Aug 05 18:24:07 a71602a86b27 configure-balena-root-ca.sh[1192]: Running hooks in /etc/ca-certificates/update.d...
Aug 05 18:24:07 a71602a86b27 configure-balena-root-ca.sh[1192]: done.
Aug 05 18:24:07 a71602a86b27 systemd[1]: Started balena-root-ca.
```

Change-type: patch