### PR TITLE
Install python3 for node-gyp 8.x which is used by npm 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ RUN apt-get update \
 		openvpn \
 		python \
 		python-dev \
+		python3 \
+		python3-dev \
 		rsyslog \
 		rsyslog-gnutls \
 		strace \


### PR DESCRIPTION
Change-type: patch