### PR TITLE
Remove redundant package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
VersionBot used to create that file because of a bug. The bug has long been fixed and the file is redundant.

Change-type: patch