### PR TITLE
Clear the npm cache manually before running cache clear

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN if [ "${TARGETARCH}" = "amd64" ] ; \
 	fi && \
 	curl -fsSL "${NODE_URL}" | tar xz -C /usr/local --strip-components=1 --no-same-owner \
 	&& npm install -g npm@"$NPM_VERSION" \
+	&& rm -rf /root/.npm/_cacache \
 	&& npm cache clear --force \
 	&& rm -rf /tmp/*
 


### PR DESCRIPTION
On emulated builds like arm64 the cache clear command
can fail and this seems to unblock it.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>