### PR TITLE
Maintain legacy docker tags behaviour

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -25,3 +25,4 @@ jobs:
       bake_targets: |
         default,
         no-systemd
+      docker_invert_tags: true


### PR DESCRIPTION
Change-type: patch
Depends-on: https://github.com/product-os/flowzone/pull/559