### PR TITLE
lock to prevent concurrent config updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update \
 		openssh-client \
 		openssh-server \
 		openvpn \
+		procmail \
 		python \
 		python-dev \
 		python3 \

--- a/Dockerfile.no-systemd
+++ b/Dockerfile.no-systemd
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 		nano \
 		net-tools \
 		netcat \
+		procmail \
 		strace \
 		vim \
 		wget \


### PR DESCRIPTION
when multiple instances initialise (in BoB for example) and write to `/balena/{{uuid}}.{{tld}}.env`, it could lead to config corruption (e.g. duplicate env var keys). So we get random test failures.

.. as was the case here:

https://github.com/balena-io/balena-cloud/pull/1260
https://github.com/balena-io/balena-cloud/actions/runs/4801183207/jobs/8543115448