### PR TITLE
Build confd from source to avoid upx issues in released binaries

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,8 @@
+{
+  "packageRules": [
+    {
+      "matchPackageNames": ["golang"],
+      "enabled": false
+    }
+  ]
+}

--- a/Dockerfile.no-systemd
+++ b/Dockerfile.no-systemd
@@ -1,6 +1,19 @@
-FROM debian:bookworm
+FROM golang:1.10.2 AS confd-build
 
-ENV DEBIAN_FRONTEND noninteractive
+ARG CONFD_VERSION=v0.16.0
+ARG CGO_ENABLED=0
+
+WORKDIR $GOPATH/src/github.com/kelseyhightower
+
+RUN git clone https://github.com/kelseyhightower/confd.git confd -c advice.detachedHead=false
+
+WORKDIR $GOPATH/src/github.com/kelseyhightower/confd
+
+RUN git checkout ${CONFD_VERSION} && make && make install
+
+FROM debian:bookworm AS runtime
+
+ENV DEBIAN_FRONTEND noninteractive∂
 ENV TERM xterm
 
 COPY src/01_nodoc /etc/dpkg/dpkg.cfg.d/
@@ -63,7 +76,4 @@ RUN if [ "${TARGETARCH}" = "amd64" ] ; \
 	&& rm -rf /tmp/*
 
 # Confd binary installation.
-# renovate: datasource=github-releases depName=kelseyhightower/confd
-ARG CONFD_VERSION=0.16.0
-RUN curl -fsSL -o /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-${TARGETARCH}" \
-	&& chmod a+x /usr/local/bin/confd
+COPY --from=confd-build /usr/local/bin/confd /usr/local/bin/confd


### PR DESCRIPTION
upx v3.96 (2020) fixes this issue, but that was released after the v0.16.0 confd release in 2018

Resolves: https://github.com/balena-io/balena-monitor/issues/549
Change-type: patch