### PR TITLE
Prefer using local env var values before falling back to defaults

### DIFF
--- a/src/configure-balena.sh
+++ b/src/configure-balena.sh
@@ -377,8 +377,12 @@ if [[ -f "${CONF}" ]]; then
 	do
 		VARNAME="$(echo "${EV}" | sed -r 's/(^[^=]*)=(.*)$/\1/')"
 		VARVALUE="$(echo "${EV}" | sed -r 's/(^[^=]*)=(.*)$/\2/')"
+		# prefer the local value if there is one
+		if [[ -n $VARNAME ]] && [[ -n ${!VARNAME} ]]; then
+			VARVALUE=${!VARNAME}
+		fi
 		if [[ -n $VARNAME ]] && [[ -n $VARVALUE ]]; then
-			grep -Eq "^${VARNAME}=" /etc/docker.env || echo "${EV}" >> /etc/docker.env
+			grep -Eq "^${VARNAME}=" /etc/docker.env || echo "${VARNAME}=${VARVALUE}" >> /etc/docker.env
 		fi
 	done
 fi


### PR DESCRIPTION
#316 changed the behavior and configure-balena.sh no longer uses the local envs when defined while populating /etc/docker.env.
Found once the API started complaining about REDIS_HOST being in an invalid format, which while we defined it in the docker-compose.yml as `<host>:<port>`, at the end on runtime it had the default `redis.<tld>` as its value.

Change-type: patch
See: https://github.com/balena-io-modules/open-balena-base/pull/316/files#diff-95ccd7ac2401d4f914cf825fabd8648b9db8a1f5436aafcedf3a640e9a1b73b6R376-R378
See: https://balena.zulipchat.com/#narrow/stream/346007-balena-io.2FbalenaCloud/topic/BoB.20REDIS_HOST.20error.20on.20livepush