### PR TITLE
Move the no-systemd compatibility tag to a suffix

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -25,4 +25,3 @@ jobs:
       bake_targets: |
         default,
         no-systemd
-      docker_invert_tags: true


### PR DESCRIPTION
We kept it as a prefix for historical reasons, but renovate versioning expects the docker compatibility tag to follow the semver.

Repositories using `balena/open-balena-base:no-systemd-<version>` will need to update to `balena/open-balena-base:<version>-no-systemd` going forward.

Change-type: patch