### PR TITLE
Fix docker cache-from for no-system variants

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -15,8 +15,8 @@ target "no-systemd" {
   inherits = ["default"]
   dockerfile = "Dockerfile.no-systemd"
   cache-from = [
-    "docker.io/balena/open-balena-base:no-systemd-latest",
-    "docker.io/balena/open-balena-base:no-systemd-master",
+    "docker.io/balena/open-balena-base:latest-no-systemd",
+    "docker.io/balena/open-balena-base:master-no-systemd",
   ]
   platforms = [
     "linux/amd64",


### PR DESCRIPTION
See: https://github.com/balena-io-modules/open-balena-base/pull/343
Change-type: patch