### PR TITLE
Add /etc/machine-id symlink for node exporters

### DIFF
--- a/src/s6-overlay/s6-rc.d/dbus/run
+++ b/src/s6-overlay/s6-rc.d/dbus/run
@@ -5,5 +5,16 @@ exec 2>&1
 
 mkdir -p /run/dbus
 
+# Generate machine-id only if it doesn't exist (persistent across restarts)
+if [[ ! -f /var/lib/dbus/machine-id ]]; then
+    dbus-uuidgen > /var/lib/dbus/machine-id
+    chmod 644 /var/lib/dbus/machine-id
+fi
+
+# Link machine-id to /etc if needed (some apps expect it there)
+if [[ ! -f /etc/machine-id ]]; then
+    ln -sf /var/lib/dbus/machine-id /etc/machine-id
+fi
+
 # Start dbus in foreground mode
 exec dbus-daemon --system --nofork --nopidfile


### PR DESCRIPTION
See: https://balena.fibery.io/Work/Improvement/Add-s6-overlay-variant-to-open-balena-base-3163