### PR TITLE
Set up logging prefixes for longrun services

### DIFF
--- a/src/s6-overlay/s6-rc.d/avahi-daemon/run
+++ b/src/s6-overlay/s6-rc.d/avahi-daemon/run
@@ -3,8 +3,8 @@
 # Avahi daemon service for mDNS/DNS-SD
 # Runs avahi-daemon in foreground mode for s6 supervision
 
-# Set up logging
-exec 2>&1
+# Redirect all future stdout/stderr to s6-log
+exec > >(exec s6-log -b p"avahi-daemon[$$]:" 1 || true) 2>&1
 
 # Wait for dbus
 count=0

--- a/src/s6-overlay/s6-rc.d/certs-watch/run
+++ b/src/s6-overlay/s6-rc.d/certs-watch/run
@@ -5,6 +5,9 @@
 # Watch /certs directory for changes and restart confd service when detected
 # Uses inotifywait to monitor for modifications in the /certs directory
 
+# Redirect all future stdout/stderr to s6-log
+exec > >(exec s6-log -b p"certs-watch[$$]:" 1 || true) 2>&1
+
 # Create /certs directory if it doesn't exist
 mkdir -p /certs
 

--- a/src/s6-overlay/s6-rc.d/dbus/run
+++ b/src/s6-overlay/s6-rc.d/dbus/run
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Set up logging
-exec 2>&1
+# Redirect all future stdout/stderr to s6-log
+exec > >(exec s6-log -b p"dbus[$$]:" 1 || true) 2>&1
 
 mkdir -p /run/dbus
 

--- a/src/s6-overlay/scripts/confd-up.sh
+++ b/src/s6-overlay/scripts/confd-up.sh
@@ -1,6 +1,9 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
 
+# Redirect all future stdout/stderr to s6-log
+exec > >(exec s6-log -b p"confd[$$]:" 1 || true) 2>&1
+
 # Populate /etc/docker.env with all container environment variables
 for var in $(compgen -e); do
 	printf '%q=%q\n' "${var}" "${!var}"


### PR DESCRIPTION
See: https://balena.fibery.io/Work/Improvement/Add-s6-overlay-variant-to-open-balena-base-3163