### PR TITLE
Add load_env_var shared function

### DIFF
--- a/src/s6-overlay/s6-rc.d/avahi-daemon/run
+++ b/src/s6-overlay/s6-rc.d/avahi-daemon/run
@@ -3,6 +3,8 @@
 # Avahi daemon service for mDNS/DNS-SD
 # Runs avahi-daemon in foreground mode for s6 supervision
 
+set -euo pipefail
+
 # Redirect all future stdout/stderr to s6-log
 exec > >(exec s6-log -b p"avahi-daemon[$$]:" 1 || true) 2>&1
 

--- a/src/s6-overlay/s6-rc.d/dbus/run
+++ b/src/s6-overlay/s6-rc.d/dbus/run
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # Redirect all future stdout/stderr to s6-log
 exec > >(exec s6-log -b p"dbus[$$]:" 1 || true) 2>&1
 

--- a/src/s6-overlay/scripts/functions.sh
+++ b/src/s6-overlay/scripts/functions.sh
@@ -1,0 +1,19 @@
+# shellcheck shell=bash
+
+# Replicates systemd's EnvironmentFile behavior of treating everything after '=' as the complete value.
+# Usage:
+#   source /etc/s6-overlay/scripts/functions.sh 
+#   load_env_file /path/to/env/file
+load_env_file() {
+    local f="${1}" l k v
+    while IFS= read -r l || [[ -n "${l}" ]]; do
+        [[ "${l}" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=(.*)$ ]] || continue
+        k="${BASH_REMATCH[1]}" v="${BASH_REMATCH[2]}"
+        if [[ "${v}" =~ ^\"(.*)\"$ ]]; then
+            v="${BASH_REMATCH[1]}"
+        elif [[ "${v}" =~ ^\'(.*)\'$ ]]; then
+            v="${BASH_REMATCH[1]}"
+        fi
+        export "${k}=${v}"
+    done < "${f}" 2>/dev/null
+}


### PR DESCRIPTION
This shared function replicates systemd's EnvironmentFile behaviour by treating everything after the '=' as the complete value.

It should be used by services to load env files that may contain spaces in values that are unquoted and may not be bash-safe.

See: https://github.com/balena-io/balena-api/pull/5945
See: https://balena.fibery.io/Work/Improvement/Add-s6-overlay-variant-to-open-balena-base-3163
See: [#balena-io/balenaCloud > Deploys @ 💬](https://balena.zulipchat.com/#narrow/channel/346007-balena-io.2FbalenaCloud/topic/Deploys/near/536816910)