### PR TITLE
Halt container on certificate changes

### DIFF
--- a/Dockerfile.s6-overlay
+++ b/Dockerfile.s6-overlay
@@ -136,7 +136,7 @@ RUN chmod +x /etc/s6-overlay/scripts/*
 
 WORKDIR /usr/src/app
 
-ENTRYPOINT [ "/init" ]
+ENTRYPOINT [ "/etc/s6-overlay/scripts/s6-init" ]
 
 # If set, then environment is not reset and whole supervision tree sees original set of env vars.
 # It switches with-contenv into a nop.

--- a/src/s6-overlay/s6-rc.d/avahi-daemon/run
+++ b/src/s6-overlay/s6-rc.d/avahi-daemon/run
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # Redirect all future stdout/stderr to s6-log
-exec > >(exec s6-log -b p"avahi-daemon[$$]:" 1 || true) 2>&1
+exec > >(exec s6-log p"avahi-daemon[$$]:" 1 || true) 2>&1
 
 # Wait for dbus
 count=0

--- a/src/s6-overlay/s6-rc.d/certs-watch/run
+++ b/src/s6-overlay/s6-rc.d/certs-watch/run
@@ -14,5 +14,5 @@ mkdir -p /certs
 # Watch for changes and restart confd when detected
 exec inotifywait -m -e modify,create,delete,move /certs --format '%w%f %e' | while read -r file event; do
     echo "Certificate change detected: ${file} (${event})"
-    /etc/s6-overlay/scripts/confd-up.sh
+    /etc/s6-overlay/scripts/configure-balena.sh
 done

--- a/src/s6-overlay/s6-rc.d/certs-watch/run
+++ b/src/s6-overlay/s6-rc.d/certs-watch/run
@@ -6,7 +6,7 @@
 # Uses inotifywait to monitor for modifications in the /certs directory
 
 # Redirect all future stdout/stderr to s6-log
-exec > >(exec s6-log -b p"certs-watch[$$]:" 1 || true) 2>&1
+exec > >(exec s6-log p"certs-watch[$$]:" 1 || true) 2>&1
 
 # Create /certs directory if it doesn't exist
 mkdir -p /certs

--- a/src/s6-overlay/s6-rc.d/certs-watch/run
+++ b/src/s6-overlay/s6-rc.d/certs-watch/run
@@ -13,17 +13,17 @@ CERTS=${CERTS:-/certs}
 # Create /certs directory if it doesn't exist
 mkdir -p "${CERTS}"
 
-# Watch for changes with inotifywait events: modify, create, delete, move
+# Watch for changes with inotifywait events: modify, create
 # We specifically look for changes to the .ready file, which indicates that
 # cert-manager has finished it's work.
-exec inotifywait -m -e modify,create,delete,move "${CERTS}" --format '%w%f %e' | while read -r file event; do
+exec inotifywait -m -e modify,create "${CERTS}" --format '%w%f %e' | while read -r file event; do
     echo "Certificate(s) change detected: ${file} (${event})"
 
     # If the .ready file is modified/created, halt the container to pick up changes.
     # The .ready file is touched by cert-manager after it updates /certs.
     # On restart, configure-balena.sh will pick up any new/changed certificates and
     # update /etc/docker.env accordingly before other services start.
-    if [[ "${file}" = "${CERTS}/.ready" ]]; then
+    if [[ "${file}" = "${CERTS}/.ready" ]] && [[ "${event}" = "CREATE" ]]; then
         echo "Halting container to pick up changes..."
         echo 0 > /run/s6-linux-init-container-results/exitcode
         /run/s6/basedir/bin/halt

--- a/src/s6-overlay/s6-rc.d/certs-watch/run
+++ b/src/s6-overlay/s6-rc.d/certs-watch/run
@@ -2,17 +2,31 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2312
 
-# Watch /certs directory for changes and restart confd service when detected
-# Uses inotifywait to monitor for modifications in the /certs directory
+# Watch /certs directory for changes and halt the container to apply environment changes on restart.
+# Uses inotifywait to monitor for modifications in the /certs directory.
 
 # Redirect all future stdout/stderr to s6-log
 exec > >(exec s6-log p"certs-watch[$$]:" 1 || true) 2>&1
 
-# Create /certs directory if it doesn't exist
-mkdir -p /certs
+CERTS=${CERTS:-/certs}
 
-# Watch for changes and restart confd when detected
-exec inotifywait -m -e modify,create,delete,move /certs --format '%w%f %e' | while read -r file event; do
-    echo "Certificate change detected: ${file} (${event})"
-    /etc/s6-overlay/scripts/configure-balena.sh
+# Create /certs directory if it doesn't exist
+mkdir -p "${CERTS}"
+
+# Watch for changes with inotifywait events: modify, create, delete, move
+# We specifically look for changes to the .ready file, which indicates that
+# cert-manager has finished it's work.
+exec inotifywait -m -e modify,create,delete,move "${CERTS}" --format '%w%f %e' | while read -r file event; do
+    echo "Certificate(s) change detected: ${file} (${event})"
+
+    # If the .ready file is modified/created, halt the container to pick up changes.
+    # The .ready file is touched by cert-manager after it updates /certs.
+    # On restart, configure-balena.sh will pick up any new/changed certificates and
+    # update /etc/docker.env accordingly before other services start.
+    if [[ "${file}" = "${CERTS}/.ready" ]]; then
+        echo "Halting container to pick up changes..."
+        echo 0 > /run/s6-linux-init-container-results/exitcode
+        /run/s6/basedir/bin/halt
+    fi
+    
 done

--- a/src/s6-overlay/s6-rc.d/confd/up
+++ b/src/s6-overlay/s6-rc.d/confd/up
@@ -1,1 +1,1 @@
-/etc/s6-overlay/scripts/confd-up.sh
+/etc/s6-overlay/scripts/confd-up

--- a/src/s6-overlay/s6-rc.d/dbus/run
+++ b/src/s6-overlay/s6-rc.d/dbus/run
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Redirect all future stdout/stderr to s6-log
-exec > >(exec s6-log -b p"dbus[$$]:" 1 || true) 2>&1
+exec > >(exec s6-log p"dbus[$$]:" 1 || true) 2>&1
 
 mkdir -p /run/dbus
 

--- a/src/s6-overlay/scripts/confd-up
+++ b/src/s6-overlay/scripts/confd-up
@@ -4,9 +4,4 @@
 # Redirect all future stdout/stderr to s6-log
 exec > >(exec s6-log p"confd[$$]:" 1 || true) 2>&1
 
-# Populate /etc/docker.env with all container environment variables
-for var in $(compgen -e); do
-	printf '%q=%q\n' "${var}" "${!var}"
-done > /etc/docker.env
-
 exec /etc/s6-overlay/scripts/configure-balena.sh

--- a/src/s6-overlay/scripts/confd-up.sh
+++ b/src/s6-overlay/scripts/confd-up.sh
@@ -2,7 +2,7 @@
 # shellcheck shell=bash
 
 # Redirect all future stdout/stderr to s6-log
-exec > >(exec s6-log -b p"confd[$$]:" 1 || true) 2>&1
+exec > >(exec s6-log p"confd[$$]:" 1 || true) 2>&1
 
 # Populate /etc/docker.env with all container environment variables
 for var in $(compgen -e); do

--- a/src/s6-overlay/scripts/functions.sh
+++ b/src/s6-overlay/scripts/functions.sh
@@ -17,3 +17,11 @@ load_env_file() {
         export "${k}=${v}"
     done < "${f}" 2>/dev/null
 }
+
+# https://skarnet.org/software/s6/s6-svstat.html
+is_up() {
+	local service="$1"
+	local result
+	result="$(s6-svstat -u "/run/service/${service}")"
+	test "${result}" = "true"
+}

--- a/src/s6-overlay/scripts/s6-init
+++ b/src/s6-overlay/scripts/s6-init
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Populate /etc/docker.env with all container environment variables.
+# This file is updated by configure-balena.sh with zero-conf certificates
+# and other dynamic values, and is sourced before running confd again.
+for var in $(compgen -e); do
+	printf '%q=%q\n' "${var}" "${!var}"
+done > /etc/docker.env
+
+# Manually run confd once so we can use templates in s6-overlay
+/usr/local/bin/confd \
+  -onetime \
+  -confdir=/usr/src/app/config/confd \
+  -backend env
+
+# start s6 overlay
+exec /init "${@}"


### PR DESCRIPTION
Watch for cert changes and halt the container to apply environment
changes on restart.

On restart, configure-balena.sh will pick up any new/changed certificates and
update /etc/docker.env accordingly before other services start.

This is the cleanest way to ensure any already running services get the
new environment variables when certificates change.

Change-type: minor