### PR TITLE
Automatically set PROXY_PUBLIC_KEYS if generated by cert-manager.

### DIFF
--- a/src/configure-balena.sh
+++ b/src/configure-balena.sh
@@ -246,6 +246,7 @@ function upsert_devices_keys {
 
 		if [[ -f "${tmpubs}" ]]; then
 			replace_env_var DEVICE_CONFIG_SSH_AUTHORIZED_KEYS "$(cat < "${tmpubs}")"
+			replace_env_var PROXY_PUBLIC_KEYS "$(cat < "${tmpubs}")"
 		fi
 
 		rm -f "${tmpkeys}" "${tmpubs}"


### PR DESCRIPTION
Avoids the need to manually set the env var with the matching SSH key.

Related to: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/balenamachine-used-for-OS-testing-fails-to-connect-to-the-devices-through-the-proxy-134

Change-type: patch