### PR TITLE
Remove DSA key references

### DIFF
--- a/src/configure-balena.sh
+++ b/src/configure-balena.sh
@@ -243,7 +243,6 @@ function upsert_ssh_private_keys {
 	if [[ -d "${CERTS}/private" ]]; then
 		for ev in PROXY_SSH_KEYS_RSA \
 		  PROXY_SSH_KEYS_ECDSA \
-		  PROXY_SSH_KEYS_DSA \
 		  PROXY_SSH_KEYS_ED25519; do
 			algo="$(echo "${ev}" | awk '{split($0,arr,"_"); print arr[4]}' | tr '[:upper:]' '[:lower:]')"
 			key="${CERTS}/private/${cn}.${tld}.${algo}.key"
@@ -264,8 +263,6 @@ function upsert_git_ssh_keys_bundle {
 		local encoded
 		encoded="$(tar --transform "s|.*\.rsa\.key|id_rsa|" \
 		  --transform "s|.*\.rsa\.key.pub|id_rsa\.pub|" \
-		  --transform "s|.*\.dsa\.key|id_dsa|" \
-		  --transform "s|.*\.dsa\.key\.pub|id_dsa\.pub|" \
 		  --transform "s|.*\.ecdsa\.key|id_ecdsa|" \
 		  --transform "s|.*\.ecdsa\.key\.pub|id_ecdsa\.pub|" \
 		  --transform "s|.*\.ed25519\.key|id_ed25519|" \


### PR DESCRIPTION
We recently dropped DSA key generation from cert-manager as the latest ssh-keygen no longer supports it. Removing references to those keys from this codebase as well.

Change-type: patch

---

See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/Console-pod-not-coming-online-209